### PR TITLE
Add getters to AbstractForgeAttribute

### DIFF
--- a/forge16/src/main/java/com/envyful/api/forge/player/attribute/AbstractForgeAttribute.java
+++ b/forge16/src/main/java/com/envyful/api/forge/player/attribute/AbstractForgeAttribute.java
@@ -34,4 +34,12 @@ public abstract class AbstractForgeAttribute<A> implements PlayerAttribute<A> {
     public UUID getUuid() {
         return this.uuid;
     }
+
+    public ForgeEnvyPlayer getParent() {
+        return parent;
+    }
+
+    public A getManager() {
+        return manager;
+    }
 }


### PR DESCRIPTION
The fields are protected and final, a getter would be needed to get the player for the the forge attribute.