### PR TITLE
UtilWorld#getRandomPosition's y level always being zero

### DIFF
--- a/forge16/src/main/java/com/envyful/api/forge/world/UtilWorld.java
+++ b/forge16/src/main/java/com/envyful/api/forge/world/UtilWorld.java
@@ -25,7 +25,7 @@ public class UtilWorld {
                 0,
                 (UtilRandom.randomBoolean() ? 1 : -1) * UtilRandom.randomInteger(0, radiusZ));
 
-        int y = world.getHeight(Heightmap.Type.MOTION_BLOCKING, pos.getX(), pos.getZ());
+        int y = world.getChunk(pos).getHeight(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, pos.getX(), pos.getZ());
         return new BlockPos(pos.getX(), y, pos.getZ());
     }
 


### PR DESCRIPTION
- Fixes UtilWorld#getRandomPosition's y level always being zero. This change sets the y-level to be the position's surface level