### PR TITLE
Do not save YAML default configuration files if the parent directory already exists

### DIFF
--- a/commons/src/main/java/com/envyful/api/config/yaml/YamlConfigFactory.java
+++ b/commons/src/main/java/com/envyful/api/config/yaml/YamlConfigFactory.java
@@ -119,7 +119,7 @@ public class YamlConfigFactory {
         for (var defaultConfig : defaults) {
             var file = new File(configDirectory, defaultConfig.getFileName());
 
-            if (file.exists() && !defaultConfig.shouldReplaceExisting()) {
+            if (file.getParentFile().exists() || file.exists() && !defaultConfig.shouldReplaceExisting()) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/EnvyWare/BetterDexRewards/issues/47